### PR TITLE
ruby is ambiguous

### DIFF
--- a/index.html
+++ b/index.html
@@ -1092,7 +1092,7 @@ specification by name</dd>
 
 <dt>ruby</dt>
 
-<dd>lowercase</dd>
+<dd>lowercase for the typographic convention. Uppercase for the programming language.</dd>
 
 <dt>schema</dt>
 


### PR DESCRIPTION
mostly used for typography in a spec context I suspect, but we should note the programming language exists an is occasionally mentioned.