### PR TITLE
Update RFC 2119 styling so copy/pasting text keeps uppercase formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,9 +690,8 @@ them in the <code>em</code> element, and style them with <abbr title=
        class="rfc2119"&gt;MUST&lt;/em&gt;
 
 .rfc2119 {
-  text-transform: lowercase;
-  font-variant: small-caps;
   font-style: normal;
+  font-size: 0.875em;
 }
 </pre>
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>W3C Manual of Style</title>
+  <style>
+    .rfc2119 {
+      font-style: normal;
+      font-size: 0.875em;
+    }
+  </style>
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
   </script>
     <script class='remove'>

--- a/index.html
+++ b/index.html
@@ -670,10 +670,6 @@ the experts on the public mailing list spec-prod@w3.org [<cite><a href=
   <h3><abbr title=
 "Request for Comments">RFC</abbr> 2119 Key Words</h3>
 
-<div class="issue" data-number="3" title="RFC2119 keywords are not in uppercase">
-  <p>Recent changes to ReSpec mean this is not the case in this document (which is based upon ReSpec), nor in other ReSpec generated documents.</p>
-</div>
-
 <p>Adhere to and credit <cite><abbr title=
 "Request for Comments">RFC</abbr> 2119 Key words for use in
 <abbr title="Request for Comments">RFC</abbr>s to Indicate Requirement

--- a/style.css
+++ b/style.css
@@ -166,8 +166,8 @@ var, code {
 }
 
 .rfc2119 {
-	text-transform: lowercase;
-	font-weight: bold
+	font-style: normal;
+	font-size: 0.875em;
 }
 
 #maintoc li {


### PR DESCRIPTION
Proof of concept, to illustrate proposal made in https://github.com/w3c/tr-design/issues/126#issuecomment-923500611