### PR TITLE
W3c unified style guide A-Z of W3C word list

### DIFF
--- a/a-z-w3c-word-list
+++ b/a-z-w3c-word-list
@@ -1,0 +1,158 @@
+---
+title: "A-Z of W3C word list – W3C Unified Style Guide"
+title_sentence: "A-Z of W3C word list"
+title_html: "A-Z of W3C word list"
+nav_title: "A-Z of W3C word list"
+lang: en
+order: 5
+---
+
+An alphabetised list of common W3C terms.
+
+Skip A-Z
+
+Jump to: A B C D E F G H I J L M N O P Q R S T U V W X Y Z [add anchor links to h2 headings below that contain word lists]
+
+## A
+
+- abort
+- x
+- x
+
+## B
+
+- backend, back-end
+- x
+- x
+
+## C
+
+- checkbox
+- x
+- x
+
+## D
+
+- data
+- x
+- x
+
+## E
+
+- ECMAScript
+- x
+- x
+
+## F
+
+- filename
+- x
+- x
+
+## G
+
+- grandfather
+
+## H
+
+- hand-eye coordination
+- x
+- x
+
+## I
+
+- internet
+- x
+- x
+
+## J
+
+- Java
+- x
+
+## K
+
+- x [None]
+
+## L
+
+- Level 1, 2, 3
+- x
+- x
+
+## M
+
+- markup
+- x
+- x
+
+## N
+
+- namespace
+- x
+- x
+
+## O
+
+- offline
+- x
+- x
+
+
+## P
+
+- pathname
+- x
+- x
+
+## Q
+
+- x [None]
+
+## R
+
+- read-only
+- x
+- x
+
+## S
+
+- sanity
+- x
+- x
+
+## T
+
+- timestamp
+- x
+
+## U
+
+- uppercase
+- x
+- x
+
+## V
+
+- visually impaired
+
+## W
+
+- W3C Note
+- x
+- x
+
+## X
+
+- x [None]
+
+
+## Y
+
+- x [None]
+
+## Z
+
+- zeros
+
+

--- a/home
+++ b/home
@@ -1,0 +1,24 @@
+---
+title: "W3C Unified Style Guide"
+lang: en
+lead: "Follow these guidelines when writing materials for W3C."
+resource:
+  title: "W3C Unified Style Guide"
+---
+
+{%- assign about = site.unified-style-guide | find: "name", "about.md" -%}
+## {{ about.title_sentence }}
+{{ about.content }}
+
+## Get started
+
+You can navigate the style guide:
+- section by section, using the [table of contents](#toc) below
+- as a [single continuous page](/style-guide/one-page/)
+
+## Table of contents {#toc}
+
+* [Structure and presentation](/unified-style-guide/structure-presentation/)
+* [Tone, language, and words](/unified-style-guide/tone-language-words/)
+* [Style for different content types (A–Z)](/unified-style-guide/style-different-content-types/)
+* [Grammar](/unified-style-guide/grammar/)

--- a/w3c-word-list
+++ b/w3c-word-list
@@ -1,0 +1,19 @@
+---
+title: "W3C word list – W3C Unified Style Guide"
+title_sentence: "W3C word list"
+title_html: "W3C word list"
+nav_title: "W3C word list"
+lang: en
+order: 6
+---
+
+{% include toc.html %}
+
+An alphabetised list of common W3C terms with guidance on how to write and use them.
+
+
+## Abort 
+
+Avoid using this word. Use "cancel" instead.
+
+<b>Category:</b> Avoid and replace


### PR DESCRIPTION
Create guidance for W3C terms — spelling and correct usage.

Thoughts on design:

**Principle:**
Alphabetize by the form people are most likely to search for — including incorrect or discouraged forms — and direct them immediately to the preferred wording.

**Page features**

- A–Z navigation list at the top
- search or filter field?
- links from each letter back to the A–Z navigation
- visible cross-references for related terms
- unique anchors so individual entries can be linked to directly

**Structure for each entry:**

-  The term
- The guidance
- Examples, where needed
- A category label to help people understand the type of guidance

Some words may have more than one category.

**Category labels**

- Avoid and replace
- Avoid (no direct replacement)
- Capitalization
- One word or two
- Plural
- Punctuation
- Spelling and word form
- Usage

